### PR TITLE
updated forwkflows #10

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -3,8 +3,10 @@
 name: "Release"
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
+      - dev
 
 jobs:
   # ──────────────────────────────────────────────
@@ -266,18 +268,18 @@ jobs:
           path: cantinas-cinfaes-backend/target/bom.json
 
   # ──────────────────────────────────────────────
-  # Release Publication — Promote draft release to published
+  # Release Publication — Create and publish release
   # ──────────────────────────────────────────────
   # This job only runs if all security/scan jobs above have passed.
-  # It assumes release-please has already created a DRAFT release for this tag.
-  # We attach the JAR to that draft and then promote it from draft -> published.
-  # If any upstream job fails, the release remains as a draft (invisible to consumers).
+  # It creates and publishes the release directly with the JAR and SBOM as assets.
   release:
     name: Release Publication
     runs-on: ubuntu-latest
     needs: [artifact-scanning, dast, final-sbom]
     permissions:
       contents: write
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -299,56 +301,45 @@ jobs:
         working-directory: cantinas-cinfaes-backend
         run: mvn clean package -DskipTests
 
+      - name: Read version and set tag
+        id: tag
+        env:
+          BRANCH: ${{ github.ref_name }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          VERSION=$(python3 -c "import json; print(json.load(open('.github/.release-please-manifest.json'))['.'])")
+          if [ "$BRANCH" = "dev" ]; then
+            TAG="v${VERSION}-beta.${RUN_NUMBER}"
+            PRERELEASE="true"
+          else
+            TAG="v${VERSION}"
+            PRERELEASE="false"
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
+
       - name: Download Final SBOM artifact
         uses: actions/download-artifact@v4
         with:
           name: final-sbom-${{ github.ref_name }}
           path: ./sbom
 
-      - name: Locate draft release for this tag
-        id: find_release
+      - name: Create and publish release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          PRERELEASE: ${{ steps.tag.outputs.prerelease }}
         run: |
-          echo "Looking for draft release with tag $TAG..."
-          RELEASE_ID=$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/$REPO/releases" \
-            --jq ".[] | select(.tag_name == \"$TAG\") | .id")
-
-          if [ -z "$RELEASE_ID" ]; then
-            echo "ERROR: No release found for tag $TAG."
-            echo "release-please should have created a draft release before this workflow ran."
-            exit 1
+          PRERELEASE_FLAG=""
+          if [ "$PRERELEASE" = "true" ]; then
+            PRERELEASE_FLAG="--prerelease"
           fi
-          echo "Found release ID: $RELEASE_ID"
-          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
-
-      - name: Upload JAR and SBOM to draft release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          echo "Uploading assets to draft release $TAG..."
-          gh release upload "$TAG" \
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --target "${{ github.sha }}" \
             cantinas-cinfaes-backend/target/*.jar \
             ./sbom/bom.json \
-            --clobber
-
-      - name: Promote draft release to published
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RELEASE_ID="${{ steps.find_release.outputs.release_id }}"
-          echo "Promoting release $RELEASE_ID from draft to published..."
-          gh api \
-            --method PATCH \
-            -H "Accept: application/vnd.github+json" \
-            "/repos/${{ github.repository }}/releases/$RELEASE_ID" \
-            -F draft=false
-          echo "Release published successfully."
+            $PRERELEASE_FLAG
 
   # ──────────────────────────────────────────────
   # Deploy — Push image to GHCR and deploy via SSH
@@ -357,6 +348,7 @@ jobs:
     name: Deploy to Production
     runs-on: ubuntu-latest
     needs: release
+    if: github.ref_name == 'main'
     environment: production
     permissions:
       contents: read
@@ -402,7 +394,7 @@ jobs:
           context: cantinas-cinfaes-backend
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/cantinas-cinfaes-backend:${{ github.ref_name }}
+            ghcr.io/${{ github.repository_owner }}/cantinas-cinfaes-backend:${{ needs.release.outputs.tag }}
             ghcr.io/${{ github.repository_owner }}/cantinas-cinfaes-backend:latest
 
       - name: Deploy to server via SSH
@@ -414,7 +406,7 @@ jobs:
           port: ${{ secrets.DEPLOY_PORT }}
           script: |
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            docker pull ghcr.io/${{ github.repository_owner }}/cantinas-cinfaes-backend:${{ github.ref_name }}
+            docker pull ghcr.io/${{ github.repository_owner }}/cantinas-cinfaes-backend:${{ needs.release.outputs.tag }}
             docker stop cantinas-app 2>/dev/null || true
             docker rm cantinas-app 2>/dev/null || true
             docker run -d \
@@ -427,5 +419,5 @@ jobs:
               -e MAIL_USERNAME="${{ secrets.MAIL_USERNAME }}" \
               -e MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
               -e JWT_TOKEN="${{ secrets.JWT_TOKEN }}" \
-              ghcr.io/${{ github.repository_owner }}/cantinas-cinfaes-backend:${{ github.ref_name }}
+              ghcr.io/${{ github.repository_owner }}/cantinas-cinfaes-backend:${{ needs.release.outputs.tag }}
             docker image prune -f

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,61 +1,18 @@
-name: release-please
-
 on:
-  push:
-    branches:
-      - main
-      - dev
+  workflow_dispatch:
 
 permissions:
   contents: write
+  pull-requests: write
+
+name: release-please
 
 jobs:
-  release:
+  release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Read version from manifest
-        id: version
-        run: |
-          VERSION=$(python3 -c "import json; print(json.load(open('.github/.release-please-manifest.json'))['.'])")
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Set tag name
-        id: tag
-        env:
-          BRANCH: ${{ github.ref_name }}
-          VERSION: ${{ steps.version.outputs.version }}
-          RUN_NUMBER: ${{ github.run_number }}
-        run: |
-          if [ "$BRANCH" = "dev" ]; then
-            TAG="v${VERSION}-beta.${RUN_NUMBER}"
-            PRERELEASE="true"
-          else
-            TAG="v${VERSION}"
-            PRERELEASE="false"
-          fi
-
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
-
-      - name: Create draft release
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-          TAG: ${{ steps.tag.outputs.tag }}
-          PRERELEASE: ${{ steps.tag.outputs.prerelease }}
-          SHA: ${{ github.sha }}
-        run: |
-          if gh release view "$TAG" &>/dev/null; then
-            echo "Release $TAG already exists, skipping"
-          else
-            PRERELEASE_FLAG=""
-            if [ "$PRERELEASE" = "true" ]; then
-              PRERELEASE_FLAG="--prerelease"
-            fi
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --draft \
-              --target "$SHA" \
-              $PRERELEASE_FLAG
-          fi
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .github/release-please-config.json
+          manifest-file: .github/.release-please-manifest.json


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill in the sections below so reviewers
have the context they need. Keep it concise — bullet points are fine.

⚠️ Before opening this PR, apply the required labels:
   • bug            — fixes incorrect behaviour
   • enhancement        — adds new functionality
   • documentation  — docs / comments only
    • minor          — non-breaking change
    • major          — breaking change
    • patch          — bug fix or minor enhancement
The "Require Label" check will fail until the labels are applied.
-->

### Description

This pull request updates the release automation workflows to simplify and improve the release process. The main changes are that the release publication is now triggered on every push to `main` or `dev`, releases are created and published directly (removing the draft step), and the deployment process now uses dynamically generated tags from the release job. Additionally, the `release-please` workflow is refactored to only run manually and to use the official `release-please` GitHub Action.

**Release workflow improvements:**

* The `.github/workflows/dast.yml` workflow is now triggered on pushes to `main` or `dev` instead of GitHub releases, allowing for more automated and consistent releases.
* The release job now creates and publishes releases directly with the JAR and SBOM as assets, removing the intermediate draft release step and related logic. Release tags are dynamically generated based on the branch and run number, and pre-releases are handled for the `dev` branch. [[1]](diffhunk://#diff-47fd917c8015c44e7307a53da4e919b69abbf28dedea7e9f64a423bb86481e3aL269-R282) [[2]](diffhunk://#diff-47fd917c8015c44e7307a53da4e919b69abbf28dedea7e9f64a423bb86481e3aR304-R342)
* The deployment job now uses the tag output from the release job for Docker image tagging and deployment, ensuring the correct version is deployed. [[1]](diffhunk://#diff-47fd917c8015c44e7307a53da4e919b69abbf28dedea7e9f64a423bb86481e3aL405-R397) [[2]](diffhunk://#diff-47fd917c8015c44e7307a53da4e919b69abbf28dedea7e9f64a423bb86481e3aL417-R409) [[3]](diffhunk://#diff-47fd917c8015c44e7307a53da4e919b69abbf28dedea7e9f64a423bb86481e3aL430-R422)
* Production deployment is now explicitly restricted to the `main` branch with a workflow condition.

**Release-please workflow refactoring:**

* The `.github/workflows/release-please.yml` workflow is simplified to only run manually (`workflow_dispatch`), and now uses the official `google-github-actions/release-please-action@v4` for managing releases, removing custom scripting and draft release logic.

### Type of change

<!-- Tick the one that matches the label you applied. -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation only

### How has this been tested?

<!-- Describe how you verified the change: unit tests, manual steps,
     environment, etc. Reviewers should be able to reproduce it. -->


### Checklist

- [ ] I applied the required label(s) (`bug`, `enhancement`, or `documentation`/ `minor`, `major`, or `patch`)
- [ ] My code builds locally (`mvn clean package`)
- [ ] Unit and integration tests pass
- [ ] I added or updated tests for my change where relevant
- [ ] I updated documentation where relevant
- [ ] No secrets, credentials, or sensitive data are included in this PR

### Screenshots / notes (optional)

<!-- Anything else reviewers should know: UI screenshots, trade-offs,
     follow-up work, etc. -->