### PR TITLE
fix false positive #10

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -108,6 +108,7 @@ jobs:
           -Dnvd.api.delay=2000
           -Dnvd.api.maxRetryCount=10
           -DfailBuildOnCVSS=7
+          -DsuppressionFile=dependency-check-suppressions.xml
       - name: Trivy Filesystem Scan
         uses: aquasecurity/trivy-action@master
         with:

--- a/cantinas-cinfaes-backend/dependency-check-suppressions.xml
+++ b/cantinas-cinfaes-backend/dependency-check-suppressions.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+
+  <!--
+    CVE-2026-34479: affects Log4j1XmlLayout in the log4j-1-to-2 bridge artifact.
+    CVE-2026-34477: affects SSL hostname verification in the log4j-1-to-2 bridge.
+    This project uses log4j-api only (not the bridge), so both are false positives
+    caused by CPE over-matching on the cpe:apache:log4j identifier.
+    The vulnerable class (Log4j1XmlLayout / SslConfiguration) is not present in log4j-api.
+  -->
+  <suppress>
+    <notes>False positive: CVE affects log4j-1-to-2 bridge, not log4j-api. Bridge is not used.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
+    <cve>CVE-2026-34479</cve>
+  </suppress>
+
+  <suppress>
+    <notes>False positive: CVE affects log4j-1-to-2 bridge, not log4j-api. Bridge is not used.</notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.logging\.log4j/log4j\-api@.*$</packageUrl>
+    <cve>CVE-2026-34477</cve>
+  </suppress>
+
+</suppressions>


### PR DESCRIPTION
<!--
Thanks for contributing! Please fill in the sections below so reviewers
have the context they need. Keep it concise — bullet points are fine.

⚠️ Before opening this PR, apply the required labels:
   • bug            — fixes incorrect behaviour
   • enhancement        — adds new functionality
   • documentation  — docs / comments only
    • minor          — non-breaking change
    • major          — breaking change
    • patch          — bug fix or minor enhancement
The "Require Label" check will fail until the labels are applied.
-->

### Description

This pull request improves the dependency vulnerability scanning process by adding a suppression file to filter out known false positives related to Log4j CVEs. The main changes are:

**Dependency vulnerability scanning improvements:**

* Added a new `dependency-check-suppressions.xml` file to suppress false positives for CVE-2026-34479 and CVE-2026-34477, which incorrectly flag the `log4j-api` dependency even though the project does not use the vulnerable log4j-1-to-2 bridge.
* Updated the `.github/workflows/dast.yml` workflow to use the new suppression file by passing the `-DsuppressionFile=dependency-check-suppressions.xml` option to the dependency check step.

### Type of change

<!-- Tick the one that matches the label you applied. -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Documentation only

### How has this been tested?

<!-- Describe how you verified the change: unit tests, manual steps,
     environment, etc. Reviewers should be able to reproduce it. -->


### Checklist

- [ x] I applied the required label(s) (`bug`, `enhancement`, or `documentation`/ `minor`, `major`, or `patch`)
- [ ] My code builds locally (`mvn clean package`)
- [ ] Unit and integration tests pass
- [ ] I added or updated tests for my change where relevant
- [ ] I updated documentation where relevant
- [ ] No secrets, credentials, or sensitive data are included in this PR

### Screenshots / notes (optional)

<!-- Anything else reviewers should know: UI screenshots, trade-offs,
     follow-up work, etc. -->